### PR TITLE
[GITHUB-14] Removes restart from build.yml

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -59,7 +59,6 @@
     create: no
     regexp: "^vernemq\\s+{{ item }}\\s+nofile\\s+\\d+"
     line: "vernemq {{ item }} nofile {{ sansible_vernemq_nofile }}"
-  notify: restart vernemq
   with_items:
     - soft
     - hard


### PR DESCRIPTION
VerneMQ will fail to start if not configured in the latest
versions, this means that we need to not start the service
when baking AMIs. This change removes the restart of the service
from build.yml to fix this issue.